### PR TITLE
feat(ci): add GitHub Actions workflow for Docker image auto-publishing

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,251 @@
+name: Build and Publish Docker Images
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'base/**'
+      - 'intermediate/**'
+      - 'infra/**'
+      - '.github/workflows/docker-publish.yml'
+  workflow_dispatch:
+    inputs:
+      layer:
+        description: 'Layer to build (all builds everything)'
+        default: 'all'
+        type: choice
+        options:
+          - all
+          - base
+          - intermediate
+          - infra
+      image:
+        description: 'Specific image name (optional, leave empty for all in layer)'
+        required: false
+        type: string
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_PREFIX: ghcr.io/${{ github.repository_owner }}/devcontainers
+
+jobs:
+  build-base:
+    if: github.event_name == 'push' || inputs.layer == 'all' || inputs.layer == 'base'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push base-system
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: base/base-system.Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ env.IMAGE_PREFIX }}/base-system:latest
+            ${{ env.IMAGE_PREFIX }}/base-system:${{ github.sha }}
+          cache-from: type=gha,scope=base-system
+          cache-to: type=gha,mode=max,scope=base-system
+
+  build-intermediate:
+    if: github.event_name == 'push' || inputs.layer == 'all' || inputs.layer == 'intermediate'
+    needs: build-base
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        image: [rust, go]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push ${{ matrix.image }}
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: intermediate/${{ matrix.image }}.Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ env.IMAGE_PREFIX }}/${{ matrix.image }}:latest
+            ${{ env.IMAGE_PREFIX }}/${{ matrix.image }}:${{ github.sha }}
+          cache-from: type=gha,scope=${{ matrix.image }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.image }}
+          build-contexts: |
+            base-system:latest=docker-image://${{ env.IMAGE_PREFIX }}/base-system:latest
+
+  build-infra-base:
+    if: github.event_name == 'push' || inputs.layer == 'all' || inputs.layer == 'infra'
+    needs: build-base
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - coinbase
+          - coinbase_ethereum
+          - coinbase_ethereum_solana
+          - coinbase_polygon
+          - convex
+          - ethereum
+          - hardhat
+          - injective
+          - mongodb
+          - polygon
+          - postgresql
+          - universal
+          - zksync
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push ${{ matrix.image }}
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: infra/${{ matrix.image }}.Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ env.IMAGE_PREFIX }}/${{ matrix.image }}:latest
+            ${{ env.IMAGE_PREFIX }}/${{ matrix.image }}:${{ github.sha }}
+          cache-from: type=gha,scope=${{ matrix.image }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.image }}
+          build-contexts: |
+            base-system:latest=docker-image://${{ env.IMAGE_PREFIX }}/base-system:latest
+
+  build-infra-rust:
+    if: github.event_name == 'push' || inputs.layer == 'all' || inputs.layer == 'infra'
+    needs: build-intermediate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - aptos
+          - brevis
+          - foundry
+          - reth
+          - rindexer
+          - risc0
+          - solana
+          - stylus
+          - succinct
+          - sui
+          - tangle
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push ${{ matrix.image }}
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: infra/${{ matrix.image }}.Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ env.IMAGE_PREFIX }}/${{ matrix.image }}:latest
+            ${{ env.IMAGE_PREFIX }}/${{ matrix.image }}:${{ github.sha }}
+          cache-from: type=gha,scope=${{ matrix.image }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.image }}
+          build-contexts: |
+            rust:latest=docker-image://${{ env.IMAGE_PREFIX }}/rust:latest
+
+  build-infra-go:
+    if: github.event_name == 'push' || inputs.layer == 'all' || inputs.layer == 'infra'
+    needs: build-intermediate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - cosmos
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push ${{ matrix.image }}
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: infra/${{ matrix.image }}.Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ env.IMAGE_PREFIX }}/${{ matrix.image }}:latest
+            ${{ env.IMAGE_PREFIX }}/${{ matrix.image }}:${{ github.sha }}
+          cache-from: type=gha,scope=${{ matrix.image }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.image }}
+          build-contexts: |
+            go:latest=docker-image://${{ env.IMAGE_PREFIX }}/go:latest


### PR DESCRIPTION
## Summary

- Adds GitHub Actions workflow to automatically build and publish all 28 Docker images to GitHub Container Registry (ghcr.io)
- Implements proper dependency ordering: base -> intermediate -> infra layers
- Maximum parallelization within each layer using matrix builds
- Docker layer caching via GitHub Actions cache for faster rebuilds
- Triggers on push to main or manual workflow dispatch

## Image Registry

Images will be published to:
```
ghcr.io/tangle-network/devcontainers/{image-name}:latest
ghcr.io/tangle-network/devcontainers/{image-name}:{sha}
```

## Build Architecture

```
base-system (1 image)
    |
    +-- rust, go (2 images, parallel)
    |       |
    |       +-- 11 rust-based infra images (parallel)
    |       +-- 1 go-based infra image (cosmos)
    |
    +-- 13 base-only infra images (parallel)
```

## Test Plan

- [ ] Trigger workflow manually via workflow_dispatch
- [ ] Verify all images are published to ghcr.io
- [ ] Verify caching works on subsequent runs

Closes #5