### PR TITLE
fix: remove duplicated foundry container

### DIFF
--- a/infra/foundry.Dockerfile
+++ b/infra/foundry.Dockerfile
@@ -1,7 +1,0 @@
-FROM foundry:latest
-
-USER root
-RUN npm install -g ethers viem hardhat @nomicfoundation/hardhat-toolbox @nomicfoundation/hardhat-foundry
-USER agent
-
-LABEL description="foundry infrastructure layer"


### PR DESCRIPTION
# Overview

Removes duplicated foundry image (infra version), since we have an intermediate foundry image that is used already