### PR TITLE
ci: add missing infra images to docker-publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -396,6 +396,8 @@ jobs:
           - coinbase_polygon
           - ethereum
           - farcaster
+          - fhenix-foundry
+          - fhenix-hardhat
           - foundry
           - gelato
           - gnosis


### PR DESCRIPTION
## Summary
- Add 4 infra images that have Dockerfiles but were never added to the CI matrix — they were never built or pushed to GHCR
- `blockscout` (base-system dependent) → `build-infra-base`
- `fhenix-foundry` (foundry dependent) → `build-infra-foundry`
- `fhenix-hardhat` (foundry dependent) → `build-infra-foundry`
- `xlayer` (foundry dependent) → `build-infra-foundry`

## Context
Users selecting the Fhenix template in Blueprint Agent get a 403 error because `ghcr.io/tangle-network/devcontainers/fhenix-foundry:latest` was never published. Same issue would affect `fhenix-hardhat`, `blockscout`, and `xlayer`.

## Test plan
- [ ] Merge to main triggers docker-publish workflow
- [ ] Verify all 4 images appear on ghcr.io/tangle-network/devcontainers after build
- [ ] Test Fhenix template in Blueprint Agent provisions successfully