### PR TITLE
fix(infra): fix Dockerfile build issues across multiple images

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -398,7 +398,6 @@ jobs:
           - farcaster
           - fhenix-foundry
           - fhenix-hardhat
-          - foundry
           - gelato
           - gnosis
           - hardhat

--- a/infra/coinbase_ethereum_solana.Dockerfile
+++ b/infra/coinbase_ethereum_solana.Dockerfile
@@ -9,7 +9,7 @@ USER root
 
 # Install Rust
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
-    && chmod -R a+w $RUSTUP_HOME $CARGO_HOME
+    && chmod -R a+rwX $RUSTUP_HOME $CARGO_HOME
 
 # Install Node.js packages (Coinbase + Ethereum)
 RUN npm install -g @coinbase/coinbase-sdk ethers viem @wagmi/core
@@ -26,4 +26,3 @@ RUN curl --proto '=https' --tlsv1.2 -sSfL https://solana-install.solana.workers.
 USER agent
 
 LABEL description="Combined: coinbase, ethereum, solana (custom)"
-

--- a/infra/kubernetes.Dockerfile
+++ b/infra/kubernetes.Dockerfile
@@ -7,7 +7,7 @@ RUN ARCH=$(uname -m) && \
     curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash && \
     curl -Lo /usr/local/bin/kind "https://kind.sigs.k8s.io/dl/v0.25.0/kind-linux-${ARCH}" && chmod +x /usr/local/bin/kind && \
     curl -Lo /usr/local/bin/k9s.tar.gz "https://github.com/derailed/k9s/releases/latest/download/k9s_Linux_${ARCH}.tar.gz" && tar -xzf /usr/local/bin/k9s.tar.gz -C /usr/local/bin k9s && rm /usr/local/bin/k9s.tar.gz && \
-    curl -Lo /usr/local/bin/kustomize.tar.gz "https://github.com/kubernetes-sigs/kustomize/releases/latest/download/kustomize_v5.4.1_linux_${ARCH}.tar.gz" && tar -xzf /usr/local/bin/kustomize.tar.gz -C /usr/local/bin && rm /usr/local/bin/kustomize.tar.gz && \
+    curl -Lo /usr/local/bin/kustomize.tar.gz "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v5.4.1/kustomize_v5.4.1_linux_${ARCH}.tar.gz" && tar -xzf /usr/local/bin/kustomize.tar.gz -C /usr/local/bin && rm /usr/local/bin/kustomize.tar.gz && \
     pip3 install --no-cache-dir --break-system-packages kubernetes && \
     kubectl version --client && helm version && kind version && k9s version
 

--- a/infra/mongodb.Dockerfile
+++ b/infra/mongodb.Dockerfile
@@ -18,7 +18,7 @@ RUN curl -fsSL https://www.mongodb.org/static/pgp/server-8.0.asc | gpg --dearmor
 USER agent
 
 USER root
-RUN npm install -g mongodb mongoose @types/mongoose mongosh
+RUN npm install -g mongodb mongoose @types/mongoose
 USER agent
 
 LABEL description="mongodb infrastructure layer"

--- a/infra/ollama.Dockerfile
+++ b/infra/ollama.Dockerfile
@@ -7,7 +7,7 @@ RUN curl -fsSL https://ollama.ai/install.sh | sh && \
 USER agent
 
 USER root
-RUN npm install -g ollama ollama-js
+RUN npm install -g ollama
 USER agent
 
 LABEL description="ollama infrastructure layer"

--- a/infra/pulumi.Dockerfile
+++ b/infra/pulumi.Dockerfile
@@ -3,7 +3,8 @@ FROM base-system:latest
 USER root
 RUN curl -fsSL https://get.pulumi.com | sh && \
     mv /root/.pulumi/bin/* /usr/local/bin/ && \
-    pip3 install --no-cache-dir --break-system-packages pulumi pulumi-aws pulumi-gcp pulumi-kubernetes && \
+    python3 -m pip install --no-cache-dir --break-system-packages --ignore-installed --upgrade pip && \
+    python3 -m pip install --no-cache-dir --break-system-packages --ignore-installed pulumi pulumi-aws pulumi-gcp pulumi-kubernetes && \
     pulumi version
 
 USER agent

--- a/infra/solana.Dockerfile
+++ b/infra/solana.Dockerfile
@@ -19,7 +19,7 @@ RUN mkdir -p /tmp/cargo-warm && \
     rm -rf /tmp/cargo-warm
 
 USER root
-RUN chmod -R a+w $CARGO_HOME
+RUN chmod -R a+rwX $CARGO_HOME
 USER agent
 
 LABEL description="solana infrastructure layer"

--- a/infra/starknet.Dockerfile
+++ b/infra/starknet.Dockerfile
@@ -6,7 +6,8 @@ USER root
 RUN curl --proto '=https' --tlsv1.2 -sSf https://docs.swmansion.com/scarb/install.sh | sh && \
     curl -L https://raw.githubusercontent.com/foundry-rs/starknet-foundry/master/scripts/install.sh | sh && \
     if [ -f /root/.local/bin/snfoundryup ]; then /root/.local/bin/snfoundryup; fi && \
-    pip3 install --no-cache-dir --break-system-packages cairo-lang starknet-py
+    python3 -m pip install --no-cache-dir --break-system-packages --ignore-installed --upgrade pip && \
+    python3 -m pip install --no-cache-dir --break-system-packages --ignore-installed cairo-lang starknet-py
 
 USER agent
 

--- a/infra/stylus.Dockerfile
+++ b/infra/stylus.Dockerfile
@@ -1,10 +1,9 @@
 FROM foundry:latest
 
 USER root
-RUN rustup target add wasm32-unknown-unknown
+RUN rustup target add wasm32-unknown-unknown && \
+    cargo install cargo-stylus
 
 USER agent
-
-RUN cargo install cargo-stylus
 
 LABEL description="stylus infrastructure layer"

--- a/infra/tangle.Dockerfile
+++ b/infra/tangle.Dockerfile
@@ -2,21 +2,24 @@ FROM rust:latest
 
 USER root
 RUN npm install -g @tangle-network/tangle-substrate-types
-USER agent
 
-RUN cargo install subxt-cli --version 0.39.0
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends protobuf-compiler libprotobuf-dev && \
+    rm -rf /var/lib/apt/lists/*
 
-RUN cargo install --git https://github.com/tangle-network/blueprint-sdk --branch v2 cargo-tangle
+ENV PROTOC=/usr/bin/protoc \
+    PROTOC_INCLUDE=/usr/include
+
+ARG CARGO_TANGLE_VERSION=0.4.0-alpha.22
+RUN cargo install --locked cargo-tangle --version ${CARGO_TANGLE_VERSION}
 
 # Pre-warm cargo cache with project-specific crates
 RUN mkdir -p /tmp/cargo-warm && \
-    printf '[package]\nname = "warm"\nversion = "0.0.0"\nedition = "2021"\n\n[dependencies]\nsubxt = "0.39"\nsp-core = "*"\nsp-runtime = "*"\nframe-support = "*"\n' > /tmp/cargo-warm/Cargo.toml && \
+    printf '[package]\nname = "warm"\nversion = "0.0.0"\nedition = "2021"\n\n[dependencies]\nsp-core = "*"\nsp-runtime = "*"\nframe-support = "*"\n' > /tmp/cargo-warm/Cargo.toml && \
     mkdir -p /tmp/cargo-warm/src && echo 'fn main() {}' > /tmp/cargo-warm/src/main.rs && \
     cd /tmp/cargo-warm && cargo fetch && \
     rm -rf /tmp/cargo-warm
 
-USER root
-RUN chmod -R a+w $CARGO_HOME
 USER agent
 
 LABEL description="tangle infrastructure layer"

--- a/infra/tensorflow-cpu.Dockerfile
+++ b/infra/tensorflow-cpu.Dockerfile
@@ -1,7 +1,7 @@
 FROM scientific-python:latest
 
 USER root
-RUN pip3 install --no-cache-dir --break-system-packages tensorflow-cpu keras && \
+RUN pip3 install --no-cache-dir --break-system-packages tensorflow keras && \
     python3 -c 'import tensorflow as tf; print(f"TensorFlow {tf.__version__} (CPU)")'
 
 USER agent

--- a/infra/ton.Dockerfile
+++ b/infra/ton.Dockerfile
@@ -7,7 +7,7 @@ RUN npm install -g @ton-community/func-js && \
 USER agent
 
 USER root
-RUN npm install -g @ton/core @ton/crypto @ton/ton @ton/blueprint @tact-lang/compiler ton-access
+RUN npm install -g @ton/core @ton/crypto @ton/ton @ton/blueprint @tact-lang/compiler
 USER agent
 
 LABEL description="ton infrastructure layer"

--- a/infra/universal.Dockerfile
+++ b/infra/universal.Dockerfile
@@ -16,8 +16,8 @@ RUN apt-get update && \
 USER agent
 
 USER root
-RUN ARCH=$(dpkg --print-architecture) && if [ "$ARCH" = "amd64" ]; then GO_ARCH="amd64"; elif [ "$ARCH" = "arm64" ]; then GO_ARCH="arm64"; else echo "Unsupported architecture: $ARCH"; exit 1; fi && curl -fsSL https://go.dev/dl/go1.22.0.linux-${GO_ARCH}.tar.gz | tar -C /usr/local -xzf - && mkdir -p /go/bin /go/pkg /go/src && chmod -R a+w /go && \
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && chmod -R a+w $RUSTUP_HOME $CARGO_HOME && rustup component add rustfmt clippy rust-analyzer && \
+RUN ARCH=$(dpkg --print-architecture) && if [ "$ARCH" = "amd64" ]; then GO_ARCH="amd64"; elif [ "$ARCH" = "arm64" ]; then GO_ARCH="arm64"; else echo "Unsupported architecture: $ARCH"; exit 1; fi && curl -fsSL https://go.dev/dl/go1.22.0.linux-${GO_ARCH}.tar.gz | tar -C /usr/local -xzf - && mkdir -p /go/bin /go/pkg /go/src && chmod -R a+rwX /go && \
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && chmod -R a+rwX $RUSTUP_HOME $CARGO_HOME && rustup component add rustfmt clippy rust-analyzer && \
     curl -sSL https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer && \
     gem install bundler && \
     KOTLIN_VERSION=$(curl -s https://api.github.com/repos/JetBrains/kotlin/releases/latest | grep '"tag_name"' | sed -E 's/.*"v([^"]+)".*/\1/') && curl -sL https://github.com/JetBrains/kotlin/releases/download/v${KOTLIN_VERSION}/kotlin-compiler-${KOTLIN_VERSION}.zip -o kotlin.zip && unzip -q kotlin.zip -d /opt && rm kotlin.zip && chmod -R a+rx /opt/kotlinc && \

--- a/intermediate/rust.Dockerfile
+++ b/intermediate/rust.Dockerfile
@@ -6,7 +6,7 @@ ENV RUSTUP_HOME=/usr/local/rustup \
 
 USER root
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
-    && chmod -R a+w $RUSTUP_HOME $CARGO_HOME
+    && chmod -R a+rwX $RUSTUP_HOME $CARGO_HOME
 
 # Pre-warm cargo cache with commonly used crates
 RUN mkdir -p /tmp/cargo-warm && \
@@ -15,7 +15,7 @@ RUN mkdir -p /tmp/cargo-warm && \
     echo 'fn main() {}' > /tmp/cargo-warm/src/main.rs && \
     cd /tmp/cargo-warm && cargo fetch && \
     rm -rf /tmp/cargo-warm && \
-    chmod -R a+w $CARGO_HOME
+    chmod -R a+rwX $CARGO_HOME
 
 # Install rust-analyzer LSP for Rust code intelligence
 RUN rustup component add rust-analyzer && \


### PR DESCRIPTION
## Summary
- **Permissions:** Use `chmod a+rwX` instead of `a+w` for Rust/Go directories across all images (rust intermediate, coinbase_ethereum_solana, solana, universal). The `X` flag adds execute on directories for traversal, fixing agent user access.
- **Tangle:** Remove `subxt-cli` and `subxt` cargo-warm dependency (not needed), install `cargo-tangle` from crates.io with pinned version instead of git branch, add protobuf deps for substrate crate compilation.
- **Kubernetes:** Fix kustomize download URL (was using `/releases/latest/download/` but kustomize uses `/releases/download/kustomize/v5.4.1/`).
- **Package cleanup:** Remove non-existent or redundant npm packages (`ollama-js`, `ton-access`, `mongosh` which is installed via apt).
- **Python fixes:** Use `python3 -m pip` with `--ignore-installed` in pulumi and starknet to avoid pip conflicts.
- **Tensorflow:** Use `tensorflow` instead of `tensorflow-cpu` (the latter is deprecated).
- **Stylus:** Run `cargo install cargo-stylus` as root (was running as agent user without write access to cargo home).
- **CI:** Remove duplicate `foundry` entry from build matrix.

## Test plan
- [ ] Verify CI build matrix runs successfully for all modified images
- [ ] Spot-check that tangle image builds without subxt
- [ ] Confirm rust intermediate image allows agent user to run cargo commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)