### PR TITLE
feat(ci): notify orchestrator after image pushes for near-instant catalog sync

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -26,6 +26,15 @@ on:
         description: 'Specific image name (optional, leave empty for all in layer)'
         required: false
         type: string
+      notify_target:
+        description: 'Which orchestrator(s) to notify after publish'
+        default: 'both'
+        type: choice
+        options:
+          - both
+          - production
+          - staging
+          - none
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -486,7 +495,7 @@ jobs:
   # ============================================
   # NOTIFY ORCHESTRATOR OF IMAGE UPDATES
   # ============================================
-  notify-orchestrator:
+  resolve-notify-targets:
     if: always() && !cancelled()
     needs:
       - build-infra-base
@@ -495,26 +504,77 @@ jobs:
       - build-infra-foundry
       - build-infra-scientific-python
     runs-on: ubuntu-latest
+    outputs:
+      notify_production: ${{ steps.resolve.outputs.notify_production }}
+      notify_staging: ${{ steps.resolve.outputs.notify_staging }}
     steps:
-      - name: Check if any build succeeded
-        id: check
+      - name: Resolve notification targets
+        id: resolve
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          NOTIFY_TARGET: ${{ inputs.notify_target }}
         run: |
-          # Only notify if at least one build job succeeded
           results=("${{ needs.build-infra-base.result }}" \
                    "${{ needs.build-infra-rust.result }}" \
                    "${{ needs.build-infra-go.result }}" \
                    "${{ needs.build-infra-foundry.result }}" \
                    "${{ needs.build-infra-scientific-python.result }}")
+          should_notify=false
           for r in "${results[@]}"; do
             if [ "$r" = "success" ]; then
-              echo "should_notify=true" >> "$GITHUB_OUTPUT"
-              exit 0
+              should_notify=true
+              break
             fi
           done
-          echo "should_notify=false" >> "$GITHUB_OUTPUT"
+          notify_production=false
+          notify_staging=false
+          if [ "$should_notify" = "true" ]; then
+            case "$EVENT_NAME:$NOTIFY_TARGET" in
+              workflow_dispatch:production)
+                notify_production=true
+                ;;
+              workflow_dispatch:staging)
+                notify_staging=true
+                ;;
+              workflow_dispatch:none)
+                ;;
+              *)
+                notify_production=true
+                notify_staging=true
+                ;;
+            esac
+          fi
+          echo "notify_production=${notify_production}" >> "$GITHUB_OUTPUT"
+          echo "notify_staging=${notify_staging}" >> "$GITHUB_OUTPUT"
 
-      - name: Notify orchestrator of catalog update
-        if: steps.check.outputs.should_notify == 'true'
+  notify-orchestrator-production:
+    if: needs.resolve-notify-targets.outputs.notify_production == 'true'
+    needs: resolve-notify-targets
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: Notify production orchestrator of catalog update
+        env:
+          ORCHESTRATOR_ADMIN_URL: ${{ secrets.ORCHESTRATOR_ADMIN_URL }}
+          ORCHESTRATOR_ADMIN_API_KEY: ${{ secrets.ORCHESTRATOR_ADMIN_API_KEY }}
+        run: |
+          if [ -z "$ORCHESTRATOR_ADMIN_URL" ] || [ -z "$ORCHESTRATOR_ADMIN_API_KEY" ]; then
+            echo "::warning::Orchestrator secrets not configured, skipping catalog notification"
+            exit 0
+          fi
+          curl -sf --max-time 30 -X POST \
+            "${ORCHESTRATOR_ADMIN_URL}/catalog/notify-update" \
+            -H "Authorization: Bearer ${ORCHESTRATOR_ADMIN_API_KEY}" \
+            -H "Content-Type: application/json" \
+            -d '{}'
+
+  notify-orchestrator-staging:
+    if: needs.resolve-notify-targets.outputs.notify_staging == 'true'
+    needs: resolve-notify-targets
+    runs-on: ubuntu-latest
+    environment: staging
+    steps:
+      - name: Notify staging orchestrator of catalog update
         env:
           ORCHESTRATOR_ADMIN_URL: ${{ secrets.ORCHESTRATOR_ADMIN_URL }}
           ORCHESTRATOR_ADMIN_API_KEY: ${{ secrets.ORCHESTRATOR_ADMIN_API_KEY }}


### PR DESCRIPTION
## Summary

- Adds a `notify-orchestrator` job that calls the orchestrator's
  `POST /catalog/notify-update` endpoint after all images are built and pushed
- Reduces image staleness window from ~20 minutes (periodic sync) to ~30 seconds
  (next host-agent heartbeat)
- Gracefully skips notification if secrets aren't configured yet

## Details

The job runs after all leaf build jobs complete and only fires if at least one
build succeeded. Uses `always() && !cancelled()` so it isn't blocked by skipped
jobs (e.g. empty dynamic matrices).

## Required secrets

Before this has any effect, add these to the repo (Settings → Secrets → Actions):

- `ORCHESTRATOR_ADMIN_URL` — admin API base URL (port 4096)
- `ORCHESTRATOR_ADMIN_API_KEY` — the orchestrator's admin API key