### PR TITLE
fix(base): keep root build caches out of /home/agent

### DIFF
--- a/base/base-system.Dockerfile
+++ b/base/base-system.Dockerfile
@@ -193,6 +193,41 @@ RUN echo 'ubuntu ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers && \
     usermod -l agent -d /home/agent -m ubuntu && \
     groupmod -n agent ubuntu
 
+COPY <<'EOF' /usr/local/bin/with-user-home
+#!/bin/sh
+set -eu
+
+remap_agent_path() {
+    var_name="$1"
+    eval "value=\${$var_name-}"
+    case "$value" in
+        /home/agent)
+            export "${var_name}=/root"
+            ;;
+        /home/agent/*)
+            export "${var_name}=/root${value#/home/agent}"
+            ;;
+    esac
+}
+
+if [ "$(id -u)" -eq 0 ]; then
+    for var_name in HOME NPM_CONFIG_CACHE npm_config_cache PNPM_HOME npm_config_store_dir CARGO_HOME RUSTUP_HOME PIP_CACHE_DIR SCCACHE_DIR GOMODCACHE MISE_DATA_DIR MISE_CACHE_DIR XDG_DATA_HOME XDG_CONFIG_HOME XDG_CACHE_HOME XDG_STATE_HOME; do
+        remap_agent_path "$var_name"
+    done
+    case "${PATH:-}" in
+        */home/agent*)
+            PATH=$(printf '%s' "$PATH" | sed 's#/home/agent#/root#g')
+            export PATH
+            ;;
+    esac
+fi
+
+exec "$@"
+EOF
+RUN chmod +x /usr/local/bin/with-user-home
+
+SHELL ["/usr/local/bin/with-user-home", "/bin/bash", "-lc"]
+
 # Consolidated environment variables
 ENV SHELL=/bin/bash \
     HOME=/home/agent \

--- a/generate_docker.test.js
+++ b/generate_docker.test.js
@@ -62,19 +62,19 @@ function testDeduplication() {
 
     setup();
 
-    generateDockerfile("ethereum_polygon_zksync");
-    const file1 = path.join(INFRA_DIR, "ethereum_polygon_zksync.Dockerfile");
+    generateDockerfile("coinbase_ethereum_polygon");
+    const file1 = path.join(INFRA_DIR, "coinbase_ethereum_polygon.Dockerfile");
     const content1 = fs.readFileSync(file1, "utf8");
 
     execSync(`rm -rf ${INFRA_DIR}`, { stdio: "ignore" });
     fs.mkdirSync(INFRA_DIR, { recursive: true });
 
-    generateDockerfile("zksync_polygon_ethereum");
-    const file2 = path.join(INFRA_DIR, "ethereum_polygon_zksync.Dockerfile");
+    generateDockerfile("polygon_coinbase_ethereum");
+    const file2 = path.join(INFRA_DIR, "coinbase_ethereum_polygon.Dockerfile");
 
     if (!fs.existsSync(file2)) {
         console.error(
-            "❌ FAILED: Expected ethereum_polygon_zksync.Dockerfile to be generated",
+            "❌ FAILED: Expected coinbase_ethereum_polygon.Dockerfile to be generated",
         );
         cleanup();
         process.exit(1);
@@ -91,7 +91,7 @@ function testDeduplication() {
     }
 
     console.log("✅ PASSED: Deduplication works correctly");
-    console.log(`   Generated file: ethereum_polygon_zksync.Dockerfile`);
+    console.log(`   Generated file: coinbase_ethereum_polygon.Dockerfile`);
     console.log(`   Content:\n${content1}`);
 
     cleanup();
@@ -101,7 +101,7 @@ function testDifferentOrders() {
     console.log("\nTesting different order combinations...");
 
     const testCases = [
-        ["coinbase_mongodb", "mongodb_coinbase"],
+        ["coinbase_ethereum", "ethereum_coinbase"],
         ["ethereum_polygon", "polygon_ethereum"],
         ["solana_sui_aptos", "aptos_solana_sui", "sui_aptos_solana"],
     ];
@@ -165,13 +165,13 @@ function testAlphabeticalSorting() {
 
     setup();
 
-    generateDockerfile("zksync_ethereum_polygon");
-    const file = path.join(INFRA_DIR, "ethereum_polygon_zksync.Dockerfile");
+    generateDockerfile("polygon_coinbase_ethereum");
+    const file = path.join(INFRA_DIR, "coinbase_ethereum_polygon.Dockerfile");
     const content = fs.readFileSync(file, "utf8");
 
     if (
         !content.includes(
-            'LABEL description="Combined: ethereum, polygon, zksync"',
+            'LABEL description="Combined: coinbase, ethereum, polygon"',
         )
     ) {
         console.error(
@@ -187,6 +187,32 @@ function testAlphabeticalSorting() {
     );
 
     cleanup();
+}
+
+function testBaseSystemRootHomeWrapper() {
+    console.log("\nTesting base-system root cache remap...");
+
+    const file = path.join(__dirname, "base", "base-system.Dockerfile");
+    const content = fs.readFileSync(file, "utf8");
+
+    if (!content.includes("COPY <<'EOF' /usr/local/bin/with-user-home")) {
+        console.error("FAILED: base-system should install with-user-home helper");
+        process.exit(1);
+    }
+
+    if (!content.includes('SHELL ["/usr/local/bin/with-user-home", "/bin/bash", "-lc"]')) {
+        console.error("FAILED: base-system should route RUN instructions through with-user-home");
+        process.exit(1);
+    }
+
+    for (const variable of ["HOME", "NPM_CONFIG_CACHE", "CARGO_HOME", "XDG_CACHE_HOME"]) {
+        if (!content.includes(variable)) {
+            console.error(`FAILED: with-user-home should remap ${variable}`);
+            process.exit(1);
+        }
+    }
+
+    console.log("PASSED: base-system remaps root cache paths away from /home/agent");
 }
 
 function testFoundryIntermediateTemplate() {
@@ -232,4 +258,5 @@ testDeduplication();
 testDifferentOrders();
 testAlphabeticalSorting();
 testFoundryIntermediateTemplate();
+testBaseSystemRootHomeWrapper();
 console.log("\n✅ All tests passed!");


### PR DESCRIPTION
## Summary
- add a `with-user-home` shell wrapper in `base/base-system.Dockerfile` and make it the inherited `SHELL` so any `RUN` executed as `root` automatically remaps `HOME`, package-manager cache vars, XDG dirs, and agent path segments from `/home/agent/...` to `/root/...`
- keep `/home/agent` as the runtime home for the `agent` user while preventing derived root-only build steps like `npm install -g`, `cargo install`, and cache warming from baking root-owned state into `/home/agent`
- refresh the checked-in Node test coverage so valid combined-image cases pass again and add a regression check for the new base-image root cache remap
- `tangle-network/agent-dev-container#392` still needs to land for runtime remediation of already-deployed poisoned caches; this PR is only the preventive image-build half

## Validation
- `node generate_docker.test.js`
- `git diff --check origin/main...HEAD`
- Local Docker builds intentionally not run per request

Fixes #29